### PR TITLE
Transfer fuels-types to own repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "fuels-types"
+version = "0.1.0"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+edition = "2021"
+homepage = "https://fuel.network/"
+license = "Apache-2.0"
+repository = "https://github.com/FuelLabs/fuels-types"
+description = "Serializable type representation for working with the Fuel VM ABI."
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+proc-macro2 = "1.0"
+strum_macros = "0.21"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,1 @@
-mod program_abi;
+pub mod program_abi;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+mod program_abi;

--- a/src/program_abi.rs
+++ b/src/program_abi.rs
@@ -1,0 +1,88 @@
+#![allow(dead_code)]
+
+//! Defines a set of serializable types required for the Fuel VM ABI.
+
+use proc_macro2::TokenStream;
+use serde::{Deserialize, Serialize};
+
+/// FuelVM ABI representation in JSON, originally specified
+/// [here](https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/abi.md).
+///
+/// This type may be used by compilers and related tooling to convert an ABI
+/// representation into native Rust structs and vice-versa.
+#[derive(Default, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProgramABI {
+    pub types: Vec<TypeDeclaration>,
+    pub functions: Vec<ABIFunction>,
+    pub logged_types: Option<Vec<LoggedType>>,
+    pub messages_types: Option<Vec<MessageType>>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ABIFunction {
+    pub inputs: Vec<TypeApplication>,
+    pub name: String,
+    pub output: TypeApplication,
+    pub attributes: Option<Vec<Attribute>>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TypeDeclaration {
+    pub type_id: usize,
+    #[serde(rename = "type")]
+    pub type_field: String,
+    pub components: Option<Vec<TypeApplication>>, // Used for custom types
+    pub type_parameters: Option<Vec<usize>>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TypeApplication {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub type_id: usize,
+    pub type_arguments: Option<Vec<TypeApplication>>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LoggedType {
+    pub log_id: u64,
+    #[serde(rename = "loggedType")]
+    pub application: TypeApplication,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MessageType {
+    pub message_id: u64,
+    #[serde(rename = "messageType")]
+    pub application: TypeApplication,
+}
+
+#[derive(Debug, Clone)]
+pub struct ResolvedLog {
+    pub log_id: u64,
+    pub param_type_call: TokenStream,
+    pub resolved_type_name: TokenStream,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Attribute {
+    pub name: String,
+    pub arguments: Vec<String>,
+}
+
+impl TypeDeclaration {
+    pub fn is_enum_type(&self) -> bool {
+        self.type_field.starts_with("enum ")
+    }
+
+    pub fn is_struct_type(&self) -> bool {
+        self.type_field.starts_with("struct ")
+    }
+}

--- a/src/program_abi.rs
+++ b/src/program_abi.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 //! Defines a set of serializable types required for the Fuel VM ABI.
 
 use proc_macro2::TokenStream;

--- a/tests/program_abi.rs
+++ b/tests/program_abi.rs
@@ -1,0 +1,24 @@
+#[cfg(test)]
+mod tests {
+    use fuels_types::program_abi::TypeDeclaration;
+
+    #[test]
+    fn detects_enum_and_struct_types() {
+        let enum_decl = type_decl_w_type_field("enum Something");
+        assert!(enum_decl.is_enum_type());
+        assert!(!enum_decl.is_struct_type());
+
+        let struct_decl = type_decl_w_type_field("struct Something");
+        assert!(struct_decl.is_struct_type());
+        assert!(!struct_decl.is_enum_type());
+    }
+
+    fn type_decl_w_type_field(type_field: &str) -> TypeDeclaration {
+        TypeDeclaration {
+            type_id: 0,
+            type_field: type_field.to_string(),
+            components: None,
+            type_parameters: None,
+        }
+    }
+}


### PR DESCRIPTION
closes https://github.com/FuelLabs/fuels-types/issues/1 

Transferred types from `packages/fuels-types/src/lib.rs` to the following repository: https://github.com/FuelLabs/fuels-types