### PR TITLE
encoding version inside ProgramABI

### DIFF
--- a/src/abi/full_program.rs
+++ b/src/abi/full_program.rs
@@ -13,6 +13,8 @@ use crate::{
     utils::TypePath,
 };
 
+use super::program::Version;
+
 /// 'Full' versions of the ABI structures are needed to simplify duplicate
 /// detection later on. The original ones([`ProgramABI`], [`TypeApplication`],
 /// [`TypeDeclaration`] and others) are not suited for this due to their use of
@@ -20,6 +22,7 @@ use crate::{
 /// represent is virtually the same.
 #[derive(Debug, Clone)]
 pub struct FullProgramABI {
+    pub encoding: Option<Version>,
     pub types: Vec<FullTypeDeclaration>,
     pub functions: Vec<FullABIFunction>,
     pub logged_types: Vec<FullLoggedType>,
@@ -66,6 +69,7 @@ impl FullProgramABI {
             .collect();
 
         Ok(Self {
+            encoding: program_abi.encoding.clone(),
             types,
             functions,
             logged_types,

--- a/src/abi/program.rs
+++ b/src/abi/program.rs
@@ -10,11 +10,40 @@ use serde::{Deserialize, Serialize};
 #[derive(Default, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProgramABI {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encoding: Option<Version>,
     pub types: Vec<TypeDeclaration>,
     pub functions: Vec<ABIFunction>,
     pub logged_types: Option<Vec<LoggedType>>,
     pub messages_types: Option<Vec<MessageType>>,
     pub configurables: Option<Vec<Configurable>>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Version(pub String);
+
+impl From<&str> for Version {
+    fn from(value: &str) -> Self {
+        Version(value.into())
+    }
+}
+
+impl Version {
+    pub fn major(&self) -> Option<&str> {
+        let s = self.0.split('.').next().map(|x| x.trim());
+        match s {
+            Some("") => None,
+            s => s,
+        }
+    }
+
+    pub fn minor(&self) -> Option<&str> {
+        let s = self.0.split('.').nth(1).map(|x| x.trim());
+        match s {
+            Some("") => None,
+            s => s,
+        }
+    }
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -84,4 +113,19 @@ pub struct Configurable {
 pub struct Attribute {
     pub name: String,
     pub arguments: Vec<String>,
+}
+
+#[test]
+fn version_extraction_test() {
+    let v = Version("1.2".to_string());
+    assert_eq!(v.major(), Some("1"));
+    assert_eq!(v.minor(), Some("2"));
+
+    let v = Version("1".to_string());
+    assert_eq!(v.major(), Some("1"));
+    assert_eq!(v.minor(), None);
+
+    let v = Version("".to_string());
+    assert_eq!(v.major(), None);
+    assert_eq!(v.minor(), None);
 }


### PR DESCRIPTION
This PR adds the field "encoding: Version" to the ProgramABI. This will be used later by Sway to inform the SDK which version of the encoding was used. 

The current version will be "0", which can also be represented with ```encoding: None```; and the new one we are developing now will be version "1".

The new JSON is at https://github.com/FuelLabs/sway/pull/5481