### PR TITLE
indirect flag for configurables

### DIFF
--- a/src/abi/full_program.rs
+++ b/src/abi/full_program.rs
@@ -260,6 +260,7 @@ pub struct FullConfigurable {
     pub name: String,
     pub application: FullTypeApplication,
     pub offset: u64,
+    pub indirect: bool,
 }
 
 impl FullConfigurable {
@@ -271,6 +272,7 @@ impl FullConfigurable {
             name: configurable.name.clone(),
             application: FullTypeApplication::from_counterpart(&configurable.application, types),
             offset: configurable.offset,
+            indirect: configurable.indirect,
         }
     }
 }

--- a/src/abi/program.rs
+++ b/src/abi/program.rs
@@ -151,6 +151,7 @@ pub struct Configurable {
     pub name: String,
     pub concrete_type_id: ConcreteTypeId,
     pub offset: u64,
+    #[serde(default)]
     pub indirect: bool,
 }
 

--- a/src/abi/program.rs
+++ b/src/abi/program.rs
@@ -151,6 +151,7 @@ pub struct Configurable {
     pub name: String,
     pub concrete_type_id: ConcreteTypeId,
     pub offset: u64,
+    pub indirect: bool,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/abi/unified_program.rs
+++ b/src/abi/unified_program.rs
@@ -369,6 +369,7 @@ pub struct UnifiedConfigurable {
     pub name: String,
     pub application: UnifiedTypeApplication,
     pub offset: u64,
+    pub indirect: bool,
 }
 
 impl UnifiedConfigurable {
@@ -384,6 +385,7 @@ impl UnifiedConfigurable {
                 concrete_types_lookup,
             ),
             offset: configurable.offset,
+            indirect: configurable.indirect,
         }
     }
 }


### PR DESCRIPTION
This PR is part of https://github.com/FuelLabs/sway/pull/6760 and it allows the ABI json to inform if a configurable encoded bytes will be load directly (at the predefined offset) or indirectly, there will another offset at the predefined offset.