### PR TITLE
Add `error_codes` to the ABI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-abi-types"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"

--- a/src/abi/full_program.rs
+++ b/src/abi/full_program.rs
@@ -90,10 +90,7 @@ impl FullProgramABI {
             logged_types,
             message_types,
             configurables,
-            error_codes: unified_program_abi
-                .error_codes
-                .clone()
-                .unwrap_or_default()
+            error_codes: unified_program_abi.error_codes.clone().unwrap_or_default(),
         })
     }
 }

--- a/src/abi/full_program.rs
+++ b/src/abi/full_program.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use crate::{abi::program::Attribute, utils::extract_custom_type_name};
 
@@ -7,6 +7,8 @@ use crate::{
     utils::TypePath,
 };
 
+use super::program::ErrorDetails;
+use super::unified_program::UnifiedMessageType;
 use super::{
     program::Version,
     unified_program::{
@@ -28,7 +30,9 @@ pub struct FullProgramABI {
     pub types: Vec<FullTypeDeclaration>,
     pub functions: Vec<FullABIFunction>,
     pub logged_types: Vec<FullLoggedType>,
+    pub message_types: Vec<FullMessageType>,
     pub configurables: Vec<FullConfigurable>,
+    pub error_codes: BTreeMap<u64, ErrorDetails>,
 }
 
 impl FullProgramABI {
@@ -63,6 +67,13 @@ impl FullProgramABI {
             .map(|logged_type| FullLoggedType::from_counterpart(logged_type, &lookup))
             .collect();
 
+        let message_types = unified_program_abi
+            .messages_types
+            .iter()
+            .flatten()
+            .map(|message_type| FullMessageType::from_counterpart(message_type, &lookup))
+            .collect();
+
         let configurables = unified_program_abi
             .configurables
             .iter()
@@ -77,7 +88,12 @@ impl FullProgramABI {
             types,
             functions,
             logged_types,
+            message_types,
             configurables,
+            error_codes: unified_program_abi
+                .error_codes
+                .clone()
+                .unwrap_or_default()
         })
     }
 }
@@ -251,6 +267,24 @@ impl FullLoggedType {
         FullLoggedType {
             log_id: logged_type.log_id.clone(),
             application: FullTypeApplication::from_counterpart(&logged_type.application, types),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FullMessageType {
+    pub log_id: String,
+    pub application: FullTypeApplication,
+}
+
+impl FullMessageType {
+    fn from_counterpart(
+        message_type: &UnifiedMessageType,
+        types: &HashMap<usize, UnifiedTypeDeclaration>,
+    ) -> FullMessageType {
+        FullMessageType {
+            log_id: message_type.message_id.clone(),
+            application: FullTypeApplication::from_counterpart(&message_type.application, types),
         }
     }
 }

--- a/src/abi/unified_program.rs
+++ b/src/abi/unified_program.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use crate::{
     abi::program::{
@@ -13,7 +13,7 @@ use crate::{
     utils::TypePath,
 };
 
-use super::program::{self, ConcreteTypeId, MessageType, TypeId, Version};
+use super::program::{self, ConcreteTypeId, ErrorDetails, MessageType, TypeId, Version};
 
 /// 'Unified' versions of the ABI structures removes concrete types and types metadata and unifies them under a single types declarations array.
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
@@ -24,8 +24,9 @@ pub struct UnifiedProgramABI {
     pub types: Vec<UnifiedTypeDeclaration>,
     pub functions: Vec<UnifiedABIFunction>,
     pub logged_types: Option<Vec<UnifiedLoggedType>>,
-    pub configurables: Option<Vec<UnifiedConfigurable>>,
     pub messages_types: Option<Vec<UnifiedMessageType>>,
+    pub configurables: Option<Vec<UnifiedConfigurable>>,
+    pub error_codes: Option<BTreeMap<u64, ErrorDetails>>,
 }
 
 impl UnifiedProgramABI {
@@ -113,16 +114,17 @@ impl UnifiedProgramABI {
             } else {
                 Some(logged_types)
             },
-            configurables: if configurables.is_empty() {
-                None
-            } else {
-                Some(configurables)
-            },
             messages_types: if messages_types.is_empty() {
                 None
             } else {
                 Some(messages_types)
             },
+            configurables: if configurables.is_empty() {
+                None
+            } else {
+                Some(configurables)
+            },
+            error_codes: program_abi.error_codes.clone(),
         })
     }
 }
@@ -243,8 +245,8 @@ impl UnifiedTypeDeclaration {
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct UnifiedTypeApplication {
-    pub type_id: usize,
     pub name: String,
+    pub type_id: usize,
     pub type_arguments: Option<Vec<UnifiedTypeApplication>>,
 }
 


### PR DESCRIPTION
# Description

This PR adds the `errorCodes` section to the ABI, as specified in the [ABI Errors RFC](https://github.com/FuelLabs/sway-rfcs/blob/master/rfcs/0014-abi-errors.md#revert-codes):

```
"errorCodes": {
  "18446744069414584320": {
    "pos": {
      "pkg": "my_lib",
      "file": "lib.rs",
      "line": 42,
      "column": 13
    },
    "logId": null,
    "msg": "Error message."
  },
  "18446744069414584321": {
    "pos": {
      "pkg": "my_contract",
      "file": "main.rs",
      "line": 21,
      "column": 34
    },
    "logId": "4933727799282657266",
    "msg": null
  }
}
```

The proposed structure differs slightly from the original proposal, as it adds the `pkg` field. The intention of this field is to clearly distinguish between the package in which the error occurs and the file path within the package.

Separating the package from the file path:
- gives clear distinction in which package the error occurs.
- supports the cases where the package name as defined in the `Forc.toml` does not need to be the same as the directory name. Having the package name as a part of the file path would in such cases be misleading and confusing.
- opens the possibility of having also the package version encoded, once we have it available in the compiler. E.g. "my_lib@1.2.0".