### PR TITLE
Add `error_message` to `TypeApplication`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-abi-types"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"

--- a/src/abi/full_program.rs
+++ b/src/abi/full_program.rs
@@ -354,9 +354,11 @@ mod tests {
             components: Some(vec![UnifiedTypeApplication {
                 name: "type_0_component_a".to_string(),
                 type_id: 1,
+                error_message: None,
                 type_arguments: Some(vec![UnifiedTypeApplication {
                     name: "type_0_type_arg_0".to_string(),
                     type_id: 2,
+                    error_message: None,
                     type_arguments: None,
                 }]),
             }]),
@@ -418,9 +420,11 @@ mod tests {
         let application = UnifiedTypeApplication {
             name: "ta_0".to_string(),
             type_id: 0,
+            error_message: None,
             type_arguments: Some(vec![UnifiedTypeApplication {
                 name: "ta_1".to_string(),
                 type_id: 1,
+                error_message: None,
                 type_arguments: None,
             }]),
         };

--- a/src/abi/program.rs
+++ b/src/abi/program.rs
@@ -101,7 +101,7 @@ pub struct TypeMetadataDeclaration {
     pub type_field: String,
     pub metadata_type_id: MetadataTypeId,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub components: Option<Vec<TypeApplication>>, // Used for custom types
+    pub components: Option<Vec<TypeApplication>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub type_parameters: Option<Vec<MetadataTypeId>>,
 }
@@ -130,6 +130,8 @@ pub struct TypeConcreteParameter {
 pub struct TypeApplication {
     pub name: String,
     pub type_id: TypeId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub type_arguments: Option<Vec<TypeApplication>>,
 }
@@ -201,6 +203,34 @@ fn version_extraction_test() {
 #[ignore = "not a test, just a convenient way to try the serialization out"]
 fn serde_json_serialization_tryout() {
     let mut abi = ProgramABI::default();
+
+    abi.concrete_types.push(TypeConcreteDeclaration {
+        type_field: "()".into(),
+        concrete_type_id: ConcreteTypeId("2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d".into()),
+        metadata_type_id: None,
+        type_arguments: None,
+    });
+
+    abi.concrete_types.push(TypeConcreteDeclaration {
+        type_field: "enum MyError".into(),
+        concrete_type_id: ConcreteTypeId("44781f4b1eb667f225275b0a1c877dd4b9a8ab01f3cd01f8ed84f95c6cd2f363".into()),
+        metadata_type_id: Some(MetadataTypeId(0)),
+        type_arguments: None,
+    });
+
+    abi.metadata_types.push(TypeMetadataDeclaration {
+        type_field: "enum MyError".into(),
+        metadata_type_id: MetadataTypeId(0),
+        components: Some(vec![
+            TypeApplication {
+                name: "MyErrorVariant".into(),
+                type_id: TypeId::Concrete(ConcreteTypeId("2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d".into())),
+                error_message: Some("My error variant error message.".into()),
+                type_arguments: None,
+            }
+        ]),
+        type_parameters: None,
+    });
 
     let mut error_codes = BTreeMap::new();
 

--- a/src/abi/program.rs
+++ b/src/abi/program.rs
@@ -206,14 +206,18 @@ fn serde_json_serialization_tryout() {
 
     abi.concrete_types.push(TypeConcreteDeclaration {
         type_field: "()".into(),
-        concrete_type_id: ConcreteTypeId("2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d".into()),
+        concrete_type_id: ConcreteTypeId(
+            "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d".into(),
+        ),
         metadata_type_id: None,
         type_arguments: None,
     });
 
     abi.concrete_types.push(TypeConcreteDeclaration {
         type_field: "enum MyError".into(),
-        concrete_type_id: ConcreteTypeId("44781f4b1eb667f225275b0a1c877dd4b9a8ab01f3cd01f8ed84f95c6cd2f363".into()),
+        concrete_type_id: ConcreteTypeId(
+            "44781f4b1eb667f225275b0a1c877dd4b9a8ab01f3cd01f8ed84f95c6cd2f363".into(),
+        ),
         metadata_type_id: Some(MetadataTypeId(0)),
         type_arguments: None,
     });
@@ -221,14 +225,14 @@ fn serde_json_serialization_tryout() {
     abi.metadata_types.push(TypeMetadataDeclaration {
         type_field: "enum MyError".into(),
         metadata_type_id: MetadataTypeId(0),
-        components: Some(vec![
-            TypeApplication {
-                name: "MyErrorVariant".into(),
-                type_id: TypeId::Concrete(ConcreteTypeId("2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d".into())),
-                error_message: Some("My error variant error message.".into()),
-                type_arguments: None,
-            }
-        ]),
+        components: Some(vec![TypeApplication {
+            name: "MyErrorVariant".into(),
+            type_id: TypeId::Concrete(ConcreteTypeId(
+                "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d".into(),
+            )),
+            error_message: Some("My error variant error message.".into()),
+            type_arguments: None,
+        }]),
         type_parameters: None,
     });
 

--- a/src/abi/unified_program.rs
+++ b/src/abi/unified_program.rs
@@ -176,6 +176,7 @@ impl UnifiedABIFunction {
             .attributes
             .as_ref()
             .map_or(vec![], Clone::clone);
+
         UnifiedABIFunction::new(
             abi_function.name.clone(),
             inputs,
@@ -247,6 +248,7 @@ impl UnifiedTypeDeclaration {
 pub struct UnifiedTypeApplication {
     pub name: String,
     pub type_id: usize,
+    pub error_message: Option<String>,
     pub type_arguments: Option<Vec<UnifiedTypeApplication>>,
 }
 
@@ -299,6 +301,7 @@ impl UnifiedTypeApplication {
         UnifiedTypeApplication {
             name: type_application.name.clone(),
             type_id: metadata_type_id.0,
+            error_message: type_application.error_message.clone(),
             type_arguments: if type_arguments.is_empty() {
                 None
             } else {
@@ -335,6 +338,11 @@ impl UnifiedTypeApplication {
         UnifiedTypeApplication {
             name,
             type_id: metadata_type_id.0,
+            // `from_concrete_type_id` is always used to describe either
+            // a type or, mostly, type arguments. It is never used for
+            // enum fields, and, thus, can never return a `UnifiedTypeApplication`
+            // with an `error_message`.
+            error_message: None,
             type_arguments: if type_arguments.is_empty() {
                 None
             } else {


### PR DESCRIPTION
This PR extends #31 by adding the `errorMessage` to the `TypeApplication`. The `errorMessage` will be set only on `TypeApplication`s that represent error type enum variants. E.g.:

For:
```
#[error_type]
enum MyError {
  #[error(m = "My error variant A error message.")]
  A: (),
  #[error(m = "My error variant B error message.")]
  B: (),
}
```
we will generate:

```
  "metadataTypes": [
    {
      "type": "enum MyError",
      "metadataTypeId": 0,
      "components": [
        {
          "name": "A",
          "typeId": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d",
          "errorMessage": "My error variant A error message."
        },
        {
          "name": "B",
          "typeId": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d",
          "errorMessage": "My error variant B error message."
        }
      ]
    }
  ]
```