### PR TITLE
Add `aliasOf` for representing aliased types in `TypeConcreteDeclaration`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-abi-types"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"

--- a/src/abi/program.rs
+++ b/src/abi/program.rs
@@ -116,6 +116,8 @@ pub struct TypeConcreteDeclaration {
     pub metadata_type_id: Option<MetadataTypeId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub type_arguments: Option<Vec<ConcreteTypeId>>,
+    #[serde(rename = "aliasOf", skip_serializing_if = "Option::is_none")]
+    pub alias_of: Option<ConcreteTypeId>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -211,6 +213,7 @@ fn serde_json_serialization_tryout() {
         ),
         metadata_type_id: None,
         type_arguments: None,
+        alias_of: None,
     });
 
     abi.concrete_types.push(TypeConcreteDeclaration {
@@ -220,6 +223,7 @@ fn serde_json_serialization_tryout() {
         ),
         metadata_type_id: Some(MetadataTypeId(0)),
         type_arguments: None,
+        alias_of: None,
     });
 
     abi.metadata_types.push(TypeMetadataDeclaration {


### PR DESCRIPTION
This PR extends `TypeConcreteDeclaration` with an `aliasOf` field adding support for representing aliased types.

For:

```sway
contract;

pub type MyAlias = Vec<b256>;

abi MyContract {
    fn test_function() -> MyAlias;
}

impl MyContract for Contract {
    fn test_function() -> MyAlias {
        MyAlias::new()
    }
}
```

We will now generate:

```json
{
  "programType": "contract",
  "specVersion": "1.1",
  "encodingVersion": "1",
  "concreteTypes": [
    {
      "type": "MyAlias",
"concreteTypeId":
"0c605f7b4155cb62f51a5c1ad9d362213c032902f0d49a2eea7ef60947bbaa42",
      "metadataTypeId": 0,
"aliasOf":
"32559685d0c9845f059bf9d472a0a38cf77d36c23dfcffe5489e86a65cdd9198"
    },
    {
      "type": "b256",
"concreteTypeId":
"7c5ee1cecf5f8eacd1284feb5f0bf2bdea533a51e2f0c9aabe9236d335989f3b"
    },
    {
      "type": "struct std::vec::Vec<b256>",
"concreteTypeId":
"32559685d0c9845f059bf9d472a0a38cf77d36c23dfcffe5489e86a65cdd9198",
      "metadataTypeId": 4,
      "typeArguments": [
"7c5ee1cecf5f8eacd1284feb5f0bf2bdea533a51e2f0c9aabe9236d335989f3b"
      ]
    }
  ],
  "metadataTypes": [
    {
      "type": "MyAlias",
      "metadataTypeId": 0,
      "components": [
        {
          "name": "buf",
          "typeId": 3,
          "typeArguments": [
            {
              "name": "",
              "typeId": 1
            }
          ]
        },
        {
          "name": "len",
          "typeId": 5
        }
      ]
    },
    {
      "type": "generic T",
      "metadataTypeId": 1
    },
    {
      "type": "raw untyped ptr",
      "metadataTypeId": 2
    },
    {
      "type": "struct std::vec::RawVec",
      "metadataTypeId": 3,
      "components": [
        {
          "name": "ptr",
          "typeId": 2
        },
        {
          "name": "cap",
          "typeId": 5
        }
      ],
      "typeParameters": [
        1
      ]
    },
    {
      "type": "struct std::vec::Vec",
      "metadataTypeId": 4,
      "components": [
        {
          "name": "buf",
          "typeId": 3,
          "typeArguments": [
            {
              "name": "",
              "typeId": 1
            }
          ]
        },
        {
          "name": "len",
          "typeId": 5
        }
      ],
      "typeParameters": [
        1
      ]
    },
    {
      "type": "u64",
      "metadataTypeId": 5
    }
  ],
  ...
}
```