### PR TITLE
Add support for representing aliases in the unified ABI representation

### DIFF
--- a/src/abi/program.rs
+++ b/src/abi/program.rs
@@ -118,8 +118,6 @@ pub struct TypeMetadataDeclaration {
     #[serde(rename = "type")]
     pub type_field: String,
     pub metadata_type_id: MetadataTypeId,
-    #[serde(skip)]
-    pub concrete_type_id: Option<ConcreteTypeId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub components: Option<Vec<TypeApplication>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -286,7 +284,6 @@ fn serde_json_serialization_tryout() {
     abi.metadata_types.push(TypeMetadataDeclaration {
         type_field: "enum MyError".into(),
         metadata_type_id: MetadataTypeId(0),
-        concrete_type_id: None,
         components: Some(vec![TypeApplication {
             name: "MyErrorVariant".into(),
             type_id: TypeId::Concrete(ConcreteTypeId(


### PR DESCRIPTION
Until now our ABI normalisation discarded type‑aliases, collapsing them into their target types.

That made it impossible to surface aliases in generated SDK bindings.
    
This PR threads alias data through every layer of the unified ABI model  so that downstream tooling can make informed decisions.

#### Key changes

* **program.rs**
    
    * Adds `concrete_type_id` to `TypeMetadataDeclaration` so that aliases can be resolved without fragile string matching.
        
* **unified_program.rs**
    
    * Populates `alias_of` when lifting concrete ABI → unified ABI.
        
    * Introduces `UnifiedTypeApplication::from_concrete_type_id` to build a synthetic application node for the aliased target.
        
* **full_program.rs**
    
    * Carries `alias_of` into `FullTypeDeclaration` as an `Arc<FullTypeApplication>`.
        
    * Adds helper methods:
        
        * `is_alias_type()` to detect alias declarations.
            
        * `alias_type_path()` to retrieve the alias’s own `TypePath`.
* * *
