### PR TITLE
Add support for representing aliases in the unified ABI representation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-abi-types"
-version = "0.15.3"
+version = "0.16.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"

--- a/src/abi/full_program.rs
+++ b/src/abi/full_program.rs
@@ -1,7 +1,10 @@
 use std::collections::{BTreeMap, HashMap};
 
 use crate::abi::program::PanickingCall;
-use crate::{abi::program::Attribute, utils::extract_custom_type_name};
+use crate::{
+    abi::program::Attribute,
+    utils::{extract_custom_type_name, extract_generic_name},
+};
 
 use crate::{
     error::{error, Error, Result},
@@ -266,6 +269,15 @@ impl FullTypeApplication {
             error_message: type_application.error_message.clone(),
         }
     }
+
+    pub fn from_declaration(type_decl: FullTypeDeclaration) -> FullTypeApplication {
+        FullTypeApplication {
+            name: type_decl.type_field.clone(),
+            type_decl,
+            type_arguments: Vec::new(),
+            error_message: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -341,6 +353,10 @@ impl FullTypeDeclaration {
 
     pub fn is_struct_type(&self) -> bool {
         self.type_field.starts_with("struct ")
+    }
+
+    pub fn generic_name(&self) -> Option<String> {
+        extract_generic_name(&self.type_field)
     }
 }
 

--- a/src/abi/program.rs
+++ b/src/abi/program.rs
@@ -123,6 +123,8 @@ pub struct TypeMetadataDeclaration {
     pub components: Option<Vec<TypeApplication>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub type_parameters: Option<Vec<MetadataTypeId>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alias_of: Option<MetadataTypeId>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -135,7 +137,7 @@ pub struct TypeConcreteDeclaration {
     pub metadata_type_id: Option<MetadataTypeId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub type_arguments: Option<Vec<ConcreteTypeId>>,
-    #[serde(rename = "aliasOf", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub alias_of: Option<ConcreteTypeId>,
 }
 
@@ -297,6 +299,7 @@ fn serde_json_serialization_tryout() {
             type_arguments: None,
         }]),
         type_parameters: None,
+        alias_of: None,
     });
 
     let mut error_codes = BTreeMap::new();


### PR DESCRIPTION
This improves on the previous representation we had, to allow more complete type support for types like arrays and tuples.